### PR TITLE
Add PartyPlayer and Parties utility class

### DIFF
--- a/src/main/java/com/google/sps/data/Comment.java
+++ b/src/main/java/com/google/sps/data/Comment.java
@@ -1,16 +1,15 @@
 package com.google.sps.data;
 
-public final class Comment {
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
 
+@AllArgsConstructor
+@Getter
+@Setter
+public final class Comment {
   private final String partyId;
   private final String text;
   private final String name;
   private final long timestamp;
-
-  public Comment(String partyId, String text, String name, long timestamp) {
-    this.partyId = partyId;
-    this.text = text;
-    this.name = name;
-    this.timestamp = timestamp;
-  }
 }

--- a/src/main/java/com/google/sps/data/YoutubeSongPlayInfo.java
+++ b/src/main/java/com/google/sps/data/YoutubeSongPlayInfo.java
@@ -1,0 +1,15 @@
+package com.google.sps.data;
+
+import com.google.sps.media.YoutubeSong;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class YoutubeSongPlayInfo {
+    private YoutubeSong song;
+    private long songStartGmtTimeMs;
+    private boolean stopped;
+}

--- a/src/main/java/com/google/sps/media/PartySongPlayer.java
+++ b/src/main/java/com/google/sps/media/PartySongPlayer.java
@@ -1,0 +1,149 @@
+package com.google.sps.media;
+
+import java.util.Calendar;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.TimeZone;
+
+import com.google.sps.data.YoutubeSongPlayInfo;
+
+/**
+ * Thread safe Object which can hold a party's list of songs, and move through them as time goes on
+ * Player is stopped by default
+ */
+public class PartySongPlayer {
+    private long currentSongStartGmtTimeMs;
+    private long stoppedPlaybackTimeMs;
+    private boolean isStopped = true;
+    private Queue<YoutubeSong> playlist;
+
+    public PartySongPlayer() {
+        playlist = new LinkedList<>();
+        stoppedPlaybackTimeMs = 0;
+    }
+    
+    private long getCurrentGmtTimeMs() {
+        return Calendar.getInstance(TimeZone.getTimeZone("GMT")).getTimeInMillis();
+    }
+
+    /**
+     * Updates the player by skipping songs that have finished playing
+     * If the player is stopped
+     */
+    private synchronized void updatePlayer() {
+        if (isStopped) {
+            // player is stopped no updates have occurred
+            return;
+        }
+        while (!playlist.isEmpty()) {
+            YoutubeSong currentSong = playlist.peek();
+            if (getCurrentGmtTimeMs() - currentSongStartGmtTimeMs < currentSong.getSongDuration()) {
+                // Currently in the middle of playing this song, no update needed
+                return;
+            } else {
+                // Current Song finished playing, start playing the next song
+                currentSongStartGmtTimeMs += currentSong.getSongDuration();
+                playlist.remove();
+            }
+        }
+        // Playlist is empty, it should be stopped
+        isStopped = true;
+        stoppedPlaybackTimeMs = 0;
+    }
+
+    /**
+     * Starts the player at the time in the song it was last stopped
+     * If there is no song to play this is a no-op
+     */
+    public synchronized void startPlayer() {
+        if (!isStopped || getCurrentSong() == null) {
+            return;
+        }
+        seek(stoppedPlaybackTimeMs);
+        isStopped = false;
+    }
+
+    /**
+     * Updates the player to start playing the current song,
+     * Saves the current time in the once playing song
+     * Stops the player
+     */
+    public synchronized void stopPlayer() {
+        updatePlayer();
+        if (isStopped) {
+            return;
+        }
+        stoppedPlaybackTimeMs = getCurrentGmtTimeMs() - currentSongStartGmtTimeMs;
+        isStopped = true;
+    }
+
+    /**
+     * Updates the player to then find the current song
+     * If there is no current song this returns null
+     */
+    public synchronized YoutubeSong getCurrentSong() {
+        updatePlayer();
+        return playlist.peek();
+    }
+
+    /**
+     * Returns information about the current song that's playing
+     * If there is no current song this returns null
+     */
+    public synchronized YoutubeSongPlayInfo getCurrentSongInformation() {
+        YoutubeSong currentSong = getCurrentSong();
+        if(currentSong == null) {
+            return null;
+        } else {
+            return new YoutubeSongPlayInfo(currentSong, currentSongStartGmtTimeMs, isStopped);
+        }
+    }
+
+    /**
+     * Plays the next song in the playlist
+     * If there is no song currently playing this is a no-op
+     * If there is no next song or the player is stopped, this only skips the current song
+     */
+    public synchronized void playNextSong() {
+        updatePlayer();
+        if (!playlist.isEmpty()){
+            if (isStopped) {
+                stoppedPlaybackTimeMs = 0;
+            } else {
+                currentSongStartGmtTimeMs = getCurrentGmtTimeMs();
+            }
+            playlist.remove();
+        }
+    }
+
+    /**
+     * adds a song to the end of the playlist
+     */
+    public synchronized void addSong(YoutubeSong song) {
+        playlist.add(song);
+    }
+
+    /**
+     * Seek to a time in the current song.
+     * If there is no current song this method is a no-op
+     * If the seek time is negative, this method is a no-op
+     * If the seek time is greater than the song duration this method will play the next song
+     * @param timeMsInSong the time to seek to
+     */
+    public synchronized void seek(long timeMsInSong) {
+        updatePlayer();
+        if (timeMsInSong < 0) {
+            return;
+        }
+        YoutubeSong currentSong = getCurrentSong();
+        if (currentSong == null) {
+            return;
+        } else if (timeMsInSong > currentSong.getSongDuration()) {
+            // Seeking to the next song
+            playNextSong();
+        } else {
+            currentSongStartGmtTimeMs = getCurrentGmtTimeMs() - timeMsInSong;
+        }
+    }
+
+}

--- a/src/main/java/com/google/sps/media/YoutubeSong.java
+++ b/src/main/java/com/google/sps/media/YoutubeSong.java
@@ -1,0 +1,14 @@
+package com.google.sps.media;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class YoutubeSong {
+    private String songName;
+    private String videoId;
+    private long songDuration;
+}

--- a/src/main/java/com/google/sps/servlets/PartyMusicPlayerServlet.java
+++ b/src/main/java/com/google/sps/servlets/PartyMusicPlayerServlet.java
@@ -1,0 +1,134 @@
+package com.google.sps.servlets;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.google.gson.Gson;
+import com.google.sps.data.YoutubeSongPlayInfo;
+import com.google.sps.media.PartySongPlayer;
+import com.google.sps.media.YoutubeSong;
+import com.google.sps.utils.Parties;
+import com.google.sps.utils.Requests;
+
+/**
+ * Uses UserService and DataStore to allow Creation, Reading, and Updating of User objects
+ * JSON is sent on GET, on POST create a new user object or update individual parameters
+ * Because all Party players are stored locally, if no player exists for a given room on a request, a default player is created
+ */
+@WebServlet("/musicPlayer")
+public class PartyMusicPlayerServlet extends HttpServlet {
+    private Map<String, PartySongPlayer> partySongPlayers = new HashMap<>();
+    private static Gson gson = new Gson();
+
+    private enum Action {
+        START_PLAYER,
+        STOP_PLAYER,
+        SKIP_SONG,
+        ADD_SONG,
+        SEEK_TIME,
+    }
+
+    /**
+     * Sends JSON of the current party-id's YoutubeSongPlayInfo
+     * If no room-id is given or a non-numeric room-id is given, return a 400 response code
+     * If there is no song playing, the response code will be 200, but there will be no message body
+     * If room-id isn't a valid room
+     */
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        System.out.println("Get Request");
+        long partyId;
+        try {
+            partyId = Long.parseLong(Requests.getParameter(request, "party-id", null));
+        } catch (Exception e) {
+            response.setStatus(400);
+            return;
+        }
+        if (!Parties.isPartyCreated(partyId)) {
+            response.setStatus(400);
+            return;
+        } else if (!Parties.isPartyPlayerCreated(partyId)) {
+            Parties.createOrReplacePartySongPlayer(partyId);
+        }
+        YoutubeSongPlayInfo currentSongInfo = Parties.getPartySongPlayer(partyId).getCurrentSongInformation();
+        if (currentSongInfo == null){
+            response.setStatus(200);
+            return;
+        } else {
+            String songPlayStatusJson = gson.toJson(currentSongInfo);
+            response.setContentType("application/json;");
+            response.getWriter().println(songPlayStatusJson);
+        }
+    }
+
+    /**
+     * Required Parameters: action, party-id
+     * Actions:
+     * START_PLAYER: starts the party's player
+     * STOP_PLAYER: stops the party's player
+     * ADD_SONG: Needs parameter "youtube-song-json", adds that song to party player's queue
+     * SKIP_SONG: skips the party player's current song
+     * SEEK_TIME: Needs parameter "seek-time", seeks to that time in the current song
+     * <p>
+     * If a needed or required parameter is missing return a 400 response code
+     * If party-id refers to a non-existent party return a 404 response code
+     */
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        long partyId;
+        Action action;
+        try {
+            partyId = Long.parseLong(Requests.getParameter(request, "party-id", null));
+            action = Action.valueOf(Requests.getParameter(request, "action", ""));
+        } catch (Exception e) {
+            response.setStatus(400);
+            return;
+        }
+        if (!Parties.isPartyCreated(partyId)) {
+            response.setStatus(404);
+            return;
+        }
+        if (!Parties.isPartyPlayerCreated(partyId)) {
+            Parties.createOrReplacePartySongPlayer(partyId);
+        }
+        PartySongPlayer currentPartyPlayer = Parties.getPartySongPlayer(partyId);
+        switch (action) {
+            case START_PLAYER:
+                currentPartyPlayer.startPlayer();
+                break;
+            case STOP_PLAYER:
+                currentPartyPlayer.stopPlayer();
+                break;
+            case ADD_SONG:
+                if (!Requests.hasParameterValue(request, "youtube-song-json")) {
+                    response.setStatus(400);
+                    return;
+                }
+                try {
+                    YoutubeSong youtubeSong = gson.fromJson(request.getParameter("youtube-song-json"), YoutubeSong.class);
+                    currentPartyPlayer.addSong(youtubeSong);
+                } catch (Exception e) {
+                    response.setStatus(400);
+                    return;
+                }
+                break;
+            case SKIP_SONG:
+                currentPartyPlayer.playNextSong();
+                break;
+            case SEEK_TIME:
+                try {
+                    long seekTimeInSong = Long.parseLong(Requests.getParameter(request, "seek-time", null));
+                    currentPartyPlayer.seek(seekTimeInSong);
+                } catch (Exception e) {
+                    response.setStatus(400);
+                    return;
+                }
+        }
+        response.sendRedirect("/party.html?id=" + partyId);
+    }
+}

--- a/src/main/java/com/google/sps/utils/Parties.java
+++ b/src/main/java/com/google/sps/utils/Parties.java
@@ -1,0 +1,54 @@
+package com.google.sps.utils;
+
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EntityNotFoundException;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.sps.media.PartySongPlayer;
+
+// TODO don't use HashMap to store Party Players
+public class Parties {
+    private static final DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    private static Map<Long, PartySongPlayer> partySongPlayers = new ConcurrentHashMap<>();
+
+    /**
+     * Queries Datastore for a User Entity with the given Id, returns null if no match
+     */
+    public static Entity getPartyEntity(long partyId) {
+
+        Key partyKey = KeyFactory.createKey("party", partyId);
+        try {
+            return datastore.get(partyKey);
+        } catch (EntityNotFoundException e) {
+            return null;
+        }
+    }
+
+    public static boolean isPartyCreated(long partyId) {
+        return getPartyEntity(partyId) != null;
+    }
+
+    public static boolean isPartyPlayerCreated(long partyId) {
+        return partySongPlayers.containsKey(partyId);
+    }
+
+    /**
+     * @return the partyId's current player or null if there is either no party with the given id or no PartySongPlayer
+     */
+    public static PartySongPlayer getPartySongPlayer(long partyId) {
+        return partySongPlayers.get(partyId);
+    }
+
+    /**
+     * Creates new PartySongPlayer for the party of given ID replacing the old player
+     */
+    public static void createOrReplacePartySongPlayer(long partyId) {
+        partySongPlayers.put(partyId, new PartySongPlayer());
+    }
+}

--- a/src/main/webapp/assets/js/script.js
+++ b/src/main/webapp/assets/js/script.js
@@ -105,3 +105,13 @@ async function showLoginBasedContent() {
         showClass("show-logged-out");
     }
 }
+
+/**
+ * Requests the current time in a song that's playing in the given roomId
+ * Note JavaScript UTC time is the same as GMT time
+ */
+async function getMsTimeInCurrentSong(partyId) {
+    const response = await fetch("/musicPlayer?party-id=" + partyId);
+    const currentYoutubeSongPlayInfo = await response.json();
+    return Date.now() - currentYoutubeSongPlayInfo.songStartGmtTimeMs;
+}


### PR DESCRIPTION
1) Why is the change being made?
---------------------------------
Each Party room will be able to play music in sync, we are accomplishing this by having all users connected to a party listen to
the server to know exactly where in a song it should be at any time. However before this change, the Server didn't store what songs would be playing,
and it didn't record where in a song it would be at any given point in time.

This change introduces the PartySongPlayer which is a Lazy implimentation of a typical music player. Instead of updating the playlist after a song completes,
this player updates itself whenever someone accesses it, this is possible because it can knows how much time has passed since the last access, and can therefore
quickly simulate all the actions that occured while nobody accessed it. This also adds quite a bit of functionality to the Party Rooms so the Parties utility class
has also been made to make interacting with data tied to parties a bit easier.

Additionally the YoutubeSongPlayInfo data class has been added to be searilize information about the current song playing in a Party at any given time.

2) What has changed?
---------------------------------
The PartySongPlayer and YoutubeSongPlayInfo classes have been implemented, and the PartyMusicPlayerServlet allows RESTful access to them.
Now using a HTTP GET request one can see the current song play info for a given room, and with a HTTP POST method one can start/stop the player, seek to a time in the song,
add songs to be played, or skip to a current time in the song.

They also both make good use of the Parties utility class which has also been implimented and allows easy access to party information and the players attached to them.

3) Testing
---------------------------------
Heavy use of PostMan to test post requests were properly taking place. From using it a bit it seems like all the changes are working as intended.