### PR TITLE
Automate username filling for logged in users

### DIFF
--- a/src/main/webapp/assets/js/script.js
+++ b/src/main/webapp/assets/js/script.js
@@ -91,14 +91,19 @@ function showClass(className) {
     }
 }
 
-function sendComment() {
-    const username = document.getElementById("user_name").value
-    const comment = document.getElementById("user_comment").value
+async function sendComment() {
+    let username;
+    if ((await isUserLoggedIn()) && (await getCurrentUser())["display-name"] !== undefined) {
+        username = (await getCurrentUser())["display-name"];
+    } else {
+        username = document.getElementById("user_name").value;
+    }
+    const comment = document.getElementById("user_comment").value;
     const queryString = window.location.search;
     const urlParams = new URLSearchParams(queryString);
     const partyId = urlParams.get('id');
     if (username.trim() !== "" && username.trim() !== "") {
-        url = `/comment?party-id=${partyId}&username=${username}&comment=${comment}`
+        url = `/comment?party-id=${partyId}&username=${username}&comment=${comment}`;
         fetch(encodeURI(url),
             {
                 headers: {
@@ -160,7 +165,9 @@ async function isUserLoggedIn() {
  */
 // TODO find better way to wait for content to exist
 async function showLoginBasedContent() {
-    await sleep(100); // avoid showing content until content exists
+    while(document.getElementsByClassName("show-logged-in").length < 4) {
+        await sleep(100); // avoid showing content until content exists
+    }
     if (await isUserLoggedIn()) {
         showClass("show-logged-in");
     } else {

--- a/src/main/webapp/party.html
+++ b/src/main/webapp/party.html
@@ -21,7 +21,7 @@
     <link rel="icon" href="assets/images/record.ico">
 </head>
 
-<body onload="loadParty()">
+<body onload="loadParty(); showLoginBasedContent();">
     <div id="header"></div>
     <div id="content">
         <h1 id="partyName">Name of the party</h1>
@@ -37,9 +37,9 @@
         <!--SUBMIT COMMENT-->
         <br/>
         <div>
-            <input type="hidden" id="party-id" name="party-id" value="bar" />
-            <p>Your name:</p>
-            <textarea name="name-comment" id="user_name" placeholder="Example name"></textarea>
+            <input type="hidden" id="party-id" name="party-id" value="bar" class="show-logged-out" />
+            <p class="show-logged-out">Your name:</p>
+            <textarea name="name-comment" id="user_name" placeholder="Example name" class="show-logged-out" ></textarea>
             <p>Comment here:</p>
             <textarea name="text-comment" id="user_comment" placeholder="Type your comment here..."></textarea>
             <br/><br/>


### PR DESCRIPTION
1) Why is the change being made?
---------------------------------
If you're logged in you shouldn't have to type in your username.

2) What has changed?
---------------------------------
The username box for commenting is only shown to logged out users, and if you're logged in then
it uses your configured displayname.

3) Other concerns and/or dependent changes?
---------------------------------
If you configure your display name to the empty-string then you can't comment.
This can be fixed by setting your display name. This is a pretty bad problem, we should show users this issue so they can fix it,
but for the alpha this known bug is admissable.