### PR TITLE
Bug fix

### DIFF
--- a/src/main/java/com/google/sps/data/PartyPlayerState.java
+++ b/src/main/java/com/google/sps/data/PartyPlayerState.java
@@ -11,7 +11,7 @@ import lombok.AllArgsConstructor;
  * The #1 use of this is for the PartyMusicPlayerServlet to be able to communicate a Player's state to a HTML requester
  */
 @AllArgsConstructor
-public class PartyPlaylistState {
+public class PartyPlayerState {
     private final YoutubeSongPlayInfo currentSongPlayInfo;
     private final List<YoutubeSong> currentPlaylist;
 }

--- a/src/main/java/com/google/sps/servlets/PartyMusicPlayerServlet.java
+++ b/src/main/java/com/google/sps/servlets/PartyMusicPlayerServlet.java
@@ -10,7 +10,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import com.google.gson.Gson;
-import com.google.sps.data.PartyPlaylistState;
+import com.google.sps.data.PartyPlayerState;
 import com.google.sps.data.YoutubeSongPlayInfo;
 import com.google.sps.media.PartySongPlayer;
 import com.google.sps.media.YoutubeSong;
@@ -54,12 +54,10 @@ public class PartyMusicPlayerServlet extends HttpServlet {
             response.setStatus(400);
             return;
         } else if (!Parties.isPartyPlayerCreated(partyId)) {
-            Parties.createOrReplacePartySongPlayer(partyId);
+            Parties.createPartySongPlayer(partyId);
         }
-        YoutubeSongPlayInfo currentSongInfo = Parties.getPartySongPlayer(partyId).getCurrentSongInformation();
-        List<YoutubeSong> currentPlaylist = Parties.getPartySongPlayer(partyId).getCurrentPlaylist();
-        PartyPlaylistState currentPlayerInfo = new PartyPlaylistState(currentSongInfo, currentPlaylist);
-        if (currentSongInfo == null){
+        PartyPlayerState currentPlayerInfo = Parties.getPartySongPlayer(partyId).getPlayerState();
+        if (currentPlayerInfo == null) {
             response.setStatus(204);
             return;
         } else {
@@ -97,7 +95,7 @@ public class PartyMusicPlayerServlet extends HttpServlet {
             return;
         }
         if (!Parties.isPartyPlayerCreated(partyId)) {
-            Parties.createOrReplacePartySongPlayer(partyId);
+            Parties.createPartySongPlayer(partyId);
         }
         PartySongPlayer currentPartyPlayer = Parties.getPartySongPlayer(partyId);
         switch (action) {

--- a/src/main/java/com/google/sps/utils/Parties.java
+++ b/src/main/java/com/google/sps/utils/Parties.java
@@ -46,9 +46,11 @@ public class Parties {
     }
 
     /**
-     * Creates new PartySongPlayer for the party of given ID replacing the old player
+     * Creates new PartySongPlayer for the party of given ID
+     * if there is already a PartySongPlayer, this method is a no-op
+     * synchronized so that PartyPlayers won't be overwritten
      */
-    public static void createOrReplacePartySongPlayer(long partyId) {
-        partySongPlayers.put(partyId, new PartySongPlayer());
+    public static synchronized void createPartySongPlayer(long partyId) {
+        partySongPlayers.putIfAbsent(partyId, new PartySongPlayer());
     }
 }

--- a/src/main/webapp/party.html
+++ b/src/main/webapp/party.html
@@ -37,14 +37,14 @@
             <button class="btn btn-outline-success my-2 my-sm-0">Search</button>
         </div>
         <!-- Volume control -->
-        <label for="Volume">V</label>
+        <label for="Volume">Volume</label>
         <input type="range" id="volume" name="volume" min="0" max="100" placeholder="100" onchange="changeVolume()">
         <!-- Add Song-->
         <h2>Add songs to queue</h2>
         <div>
             <textarea name="song_id" id="song_id" placeholder="Type the youtube id"></textarea>
             <textarea name="song_name" id="song_name" placeholder="Type song name"></textarea>
-            <input type="number" id="song_duration" name="song_duration" min="1000" placeholder="3000"  max="10000000">
+            <input type="number" id="song_duration" name="song_duration_seconds" min="1" placeholder="200"  max="10000">
             <br/><br/>
             <button class="btn btn-outline-success my-2 my-sm-0" onclick="addSong()">Add to Queue</button>
         </div>


### PR DESCRIPTION
### Synchronize Parties utility class Creation method
# --------------------------------------------------
1) Why is the change being made?
---------------------------------
The Parties utility class used the ConcurrentHashMap to store PartyPlayers, creating multiple objects with a put is dangerous because
the ConcurentHashMap implementation can return stale values. This had the potential to make different calls on the site return different players with different states.

2) What has changed?
---------------------------------
The createOrReplace method has been replaced with a create, and if there is already an existing object its a no-op. This eliminates the creation of stale values making
ConcurrentHashMap still a fine choice for storing PartyPlayers.

---------------------------------------------------------------------------------------

### Make frontend player start a stopped backend player on song addition 
# --------------------------------------------------------------------------
1) Why is the change being made?
---------------------------------
If the backend player is empty it sets its state to stopped, this can cause discrepencies between the frontend and backend.
Before the frontend only started the backend when the page was loaded, this could lead to problems because if a song finishes the backend will stop,
someone will add a song to be played, the frontend will start playing the song, and the backend will remain stopped.

2) What has changed?
---------------------------------
Now if someone adds a song to a stopped player the player will automatically restart to ensure users can listen to newly added songs.

3) Other concerns and/or dependent changes?
---------------------------------
The player is still restarted on page load, in the future this should be changed to not occur. Users should be able to start and stop the player indifferent from page reoloads.